### PR TITLE
Support Goth configured with multiple accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ config :goth,
   json: "path/to/google/json/creds.json" |> File.read!
 ```
 
+If you are configuring Goth with credentials for multiple accounts, you need to specify which one to use with Kane:
+
+```elixir
+config :kane,
+  account: "some-account@some-project.iam.gserviceaccount.com"
+```
+
 3. Ensure Kane is started before your application:
 
 ```elixir

--- a/lib/kane.ex
+++ b/lib/kane.ex
@@ -14,4 +14,18 @@ defmodule Kane do
       "https://www.googleapis.com/auth/pubsub"
   """
   def oauth_scope, do: "https://www.googleapis.com/auth/pubsub"
+
+  @doc """
+  Retrieves the Google Cloud project name from the configured credentials
+  """
+  @spec project :: String.t()
+  def project(goth_config_mod \\ Goth.Config) do
+    {:ok, project} =
+      case Application.get_env(:kane, :account) do
+        nil -> goth_config_mod.get(:project_id)
+        account -> goth_config_mod.get(account, :project_id)
+      end
+
+    project
+  end
 end

--- a/lib/kane/client.ex
+++ b/lib/kane/client.ex
@@ -34,7 +34,12 @@ defmodule Kane.Client do
   defp token_mod, do: Application.get_env(:kane, :token, Goth.Token)
 
   defp auth_header do
-    {:ok, token} = token_mod().for_scope(Kane.oauth_scope())
+    {:ok, token} =
+      case Application.get_env(:kane, :account) do
+        nil -> token_mod().for_scope(Kane.oauth_scope())
+        account -> token_mod().for_scope({account, Kane.oauth_scope()})
+      end
+
     {"Authorization", "#{token.type} #{token.token}"}
   end
 

--- a/lib/kane/message.ex
+++ b/lib/kane/message.ex
@@ -104,7 +104,6 @@ defmodule Kane.Message do
   defp path(%Topic{name: topic}), do: path(topic)
 
   defp path(topic) do
-    {:ok, project} = Goth.Config.get(:project_id)
-    "projects/#{project}/topics/#{Topic.strip!(topic)}:publish"
+    "projects/#{Kane.project()}/topics/#{Topic.strip!(topic)}:publish"
   end
 end

--- a/lib/kane/subscription.ex
+++ b/lib/kane/subscription.ex
@@ -150,12 +150,7 @@ defmodule Kane.Subscription do
     }
   end
 
-  defp project do
-    {:ok, project} = Goth.Config.get(:project_id)
-    project
-  end
-
-  defp find_path, do: "projects/#{project()}/subscriptions"
+  defp find_path, do: "projects/#{Kane.project()}/subscriptions"
   defp find_path(subscription), do: "#{find_path()}/#{strip!(subscription)}"
 
   def path(%__MODULE__{name: name}, kind), do: path(name, kind)
@@ -172,8 +167,7 @@ defmodule Kane.Subscription do
   def full_name(%__MODULE__{name: name}), do: full_name(name)
 
   def full_name(name) do
-    {:ok, project} = Goth.Config.get(:project_id)
-    "projects/#{project}/subscriptions/#{name}"
+    "projects/#{Kane.project()}/subscriptions/#{name}"
   end
 
   def strip!(name), do: String.replace(name, ~r(^#{find_path()}/?), "")

--- a/lib/kane/topic.ex
+++ b/lib/kane/topic.ex
@@ -94,11 +94,6 @@ defmodule Kane.Topic do
 
   defp with_name(name), do: %__MODULE__{name: strip!(name)}
 
-  defp project do
-    {:ok, id} = Goth.Config.get(:project_id)
-    id
-  end
-
-  defp path, do: "projects/#{project()}/topics"
+  defp path, do: "projects/#{Kane.project()}/topics"
   defp path(topic), do: "#{path()}/#{strip!(topic)}"
 end

--- a/test/kane/client_test.exs
+++ b/test/kane/client_test.exs
@@ -1,3 +1,40 @@
 defmodule Kane.ClientTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:kane, :endpoint, "http://localhost:#{bypass.port}")
+    {:ok, bypass: bypass}
+  end
+
+  test "uses the default account", %{bypass: bypass} do
+    Bypass.expect(bypass, fn conn ->
+      assert get_auth_header(conn) == "Bearer default"
+
+      Plug.Conn.resp(conn, 201, "")
+    end)
+
+    Kane.Client.get("")
+  end
+
+  test "uses the configured account", %{bypass: bypass} do
+    original_account = Application.get_env(:kane, :account)
+
+    Bypass.expect(bypass, fn conn ->
+      assert get_auth_header(conn) == "Bearer test@account.com"
+
+      Plug.Conn.resp(conn, 201, "")
+    end)
+
+    Application.put_env(:kane, :account, "test@account.com")
+    Kane.Client.get("")
+
+    Application.put_env(:kane, :account, original_account)
+  end
+
+  defp get_auth_header(conn) do
+    %{req_headers: req_headers} = conn
+    {_, auth_header} = Enum.find(req_headers, fn {header, _} -> header == "authorization" end)
+    auth_header
+  end
 end

--- a/test/kane/message_test.exs
+++ b/test/kane/message_test.exs
@@ -39,11 +39,14 @@ defmodule Kane.MessageTest do
   end
 
   test "publishing a message", %{bypass: bypass} do
-    {:ok, project} = Goth.Config.get(:project_id)
     topic = "publish"
 
     Bypass.expect(bypass, fn conn ->
-      assert Regex.match?(~r{/projects/#{project}/topics/#{topic}:publish}, conn.request_path)
+      assert Regex.match?(
+               ~r{/projects/#{Kane.project()}/topics/#{topic}:publish},
+               conn.request_path
+             )
+
       Plug.Conn.resp(conn, 201, ~s({"messageIds": [ "19916711285" ]}))
     end)
 
@@ -53,12 +56,14 @@ defmodule Kane.MessageTest do
   end
 
   test "publishing multiple messages", %{bypass: bypass} do
-    {:ok, project} = Goth.Config.get(:project_id)
     topic = "publish-multi"
     ids = ["hello", "hi", "howdy"]
 
     Bypass.expect(bypass, fn conn ->
-      assert Regex.match?(~r{/projects/#{project}/topics/#{topic}:publish}, conn.request_path)
+      assert Regex.match?(
+               ~r{/projects/#{Kane.project()}/topics/#{topic}:publish},
+               conn.request_path
+             )
 
       Plug.Conn.resp(
         conn,

--- a/test/kane/subscription_test.exs
+++ b/test/kane/subscription_test.exs
@@ -7,8 +7,7 @@ defmodule Kane.SubscriptionTest do
   setup do
     bypass = Bypass.open()
     Application.put_env(:kane, :endpoint, "http://localhost:#{bypass.port}")
-    {:ok, project} = Goth.Config.get(:project_id)
-    {:ok, bypass: bypass, project: project}
+    {:ok, bypass: bypass, project: Kane.project()}
   end
 
   test "generating the create path", %{project: project} do

--- a/test/kane/topic_test.exs
+++ b/test/kane/topic_test.exs
@@ -5,8 +5,7 @@ defmodule Kane.TopicTest do
   setup do
     bypass = Bypass.open()
     Application.put_env(:kane, :endpoint, "http://localhost:#{bypass.port}")
-    {:ok, project} = Goth.Config.get(:project_id)
-    {:ok, bypass: bypass, project: project}
+    {:ok, bypass: bypass, project: Kane.project()}
   end
 
   test "getting full name", %{project: project} do
@@ -54,9 +53,8 @@ defmodule Kane.TopicTest do
   end
 
   test "finding a topic with a fully-qualified name", %{bypass: bypass} do
-    {:ok, project} = Goth.Config.get(:project_id)
     short_name = "fqn"
-    full_name = "projects/#{project}/topics/#{short_name}"
+    full_name = "projects/#{Kane.project()}/topics/#{short_name}"
 
     Bypass.expect(bypass, fn conn ->
       assert conn.request_path == "/#{full_name}"
@@ -77,7 +75,7 @@ defmodule Kane.TopicTest do
 
   test "listing all topics", %{bypass: bypass} do
     Bypass.expect(bypass, fn conn ->
-      {:ok, project} = Goth.Config.get(:project_id)
+      project = Kane.project()
       assert Regex.match?(~r/\/projects\/#{project}\/topics/, conn.request_path)
 
       Plug.Conn.resp(conn, 200, ~s({"topics": [

--- a/test/kane_test.exs
+++ b/test/kane_test.exs
@@ -1,4 +1,29 @@
 defmodule KaneTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   doctest Kane
+
+  defmodule GothConfigMock do
+    def get(:project_id) do
+      {:ok, "default"}
+    end
+
+    def get(account, :project_id) do
+      {:ok, account}
+    end
+  end
+
+  describe "project/0" do
+    test "with no account configured" do
+      assert "default" == Kane.project(GothConfigMock)
+    end
+
+    test "with an account configured" do
+      original_account = Application.get_env(:kane, :account)
+
+      Application.put_env(:kane, :account, "test@account.com")
+      assert "test@account.com" == Kane.project(GothConfigMock)
+
+      Application.put_env(:kane, :account, original_account)
+    end
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,13 +2,17 @@ ExUnit.start()
 Application.ensure_all_started(:bypass)
 
 defmodule Kane.TestToken do
-  def for_scope(scope) do
+  def for_scope({account, scope}) do
     {:ok,
      %Goth.Token{
+       account: account,
        scope: scope,
        expires: :os.system_time(:seconds) + 3600,
        type: "Bearer",
-       token: UUID.uuid1()
+       # We use the account name as token to allow asserting on it during tests
+       token: account
      }}
   end
+
+  def for_scope(scope), do: for_scope({:default, scope})
 end


### PR DESCRIPTION
Goth can be [configured](https://github.com/peburrows/goth/tree/v1.2.0#installation) with multiple accounts. For example:

```elixir
config :goth,
  json: """
    [
      {"client_email": "account1@myproject.iam.gserviceaccount.com", ...},
      {"client_email": "account2@myproject.iam.gserviceaccount.com", ...}
    ]
    """
```

When using multiple accounts, most operations require specifying which one to use.
These changes add support for this scenario by allowing Kane to be configured to use one of the accounts:

```elixir
config :kane, account: "account2@myproject.iam.gserviceaccount.com"
```