### PR TITLE
Use encode_to_iodata

### DIFF
--- a/lib/kane/client.ex
+++ b/lib/kane/client.ex
@@ -57,5 +57,5 @@ defmodule Kane.Client do
   end
 
   defp encode!(""), do: ""
-  defp encode!(data), do: Jason.encode!(data)
+  defp encode!(data), do: Jason.encode_to_iodata!(data)
 end


### PR DESCRIPTION
This is a more efficient version than `encode` because it skips the step of building the final string. The iodata can be passed directly to HTTPoison for more efficient IO.